### PR TITLE
feat: block's timestamp and feeMultiplier in transactions

### DIFF
--- a/catapult-sdk/src/model/ModelSchemaBuilder.js
+++ b/catapult-sdk/src/model/ModelSchemaBuilder.js
@@ -135,7 +135,9 @@ class ModelSchemaBuilder {
 				height: ModelType.uint64,
 				hash: ModelType.binary,
 				merkleComponentHash: ModelType.binary,
-				index: ModelType.int
+				index: ModelType.int,
+				timestamp: ModelType.uint64,
+				feeMultiplier: ModelType.uint32
 			},
 			transactionWithMetadata: {
 				id: ModelType.objectId,

--- a/catapult-sdk/test/model/ModelSchemaBuilder_spec.js
+++ b/catapult-sdk/test/model/ModelSchemaBuilder_spec.js
@@ -277,6 +277,7 @@ describe('model schema builder', () => {
 				'transaction.deadline',
 				'transaction.maxFee',
 				'transactionMetadata.height',
+				'transactionMetadata.timestamp',
 
 				'transactionStatus.deadline',
 				'transactionStatus.height',
@@ -408,6 +409,7 @@ describe('model schema builder', () => {
 				'finalizationProof.finalizationEpoch',
 				'finalizationProof.finalizationPoint',
 				'messageGroup.stage',
+				'transactionMetadata.feeMultiplier',
 				'activityBucket.beneficiaryCount',
 				'votingPublicKey.startEpoch',
 				'votingPublicKey.endEpoch'

--- a/rest/bootstrap-preset-mainnet.yml
+++ b/rest/bootstrap-preset-mainnet.yml
@@ -17,4 +17,5 @@ gateways:
     restLoggingFilename: target/rest.log
     databaseHost: localhost
     apiNodeHost: localhost
+    restProtocol: HTTP
 

--- a/rest/bootstrap-preset-testnet.yml
+++ b/rest/bootstrap-preset-testnet.yml
@@ -17,4 +17,5 @@ gateways:
     restLoggingFilename: target/rest.log
     databaseHost: localhost
     apiNodeHost: localhost
+    restProtocol: HTTP
 

--- a/rest/src/db/CatapultDb.js
+++ b/rest/src/db/CatapultDb.js
@@ -432,15 +432,20 @@ class CatapultDb {
 			})));
 	}
 
+	/**
+	 * It retrieves and adds the block information to the transactions' meta.
+	 *
+	 * The block information includes its timestamp and feeMultiplier
+	 *
+	 * @param {object[]} list the transaction list without the added block information.
+	 * @returns {Promise<object[]>} the list with the added block information.
+	 */
 	addBlockMetaToTransactionList(list) {
-		return this.addBlockMetaToEntityList(list, ['timestamp', 'feeMultiplier'],
-			item => item.meta.height);
+		return this.addBlockMetaToEntityList(list, ['timestamp', 'feeMultiplier'], item => item.meta.height);
 	}
 
 	/**
-	 * It retrieves and adds the blocks information to the entities' meta.
-	 *
-	 * The block information includes its timestamp and feeMultiplier
+	 * It retrieves and adds the block information to the entities' meta.
 	 *
 	 * @param {object[]} list the entity list without the added block information.
 	 * @param {string[]} fields the list of fields to be be copied from the block's to the entity's meta.

--- a/rest/src/plugins/receipts/ReceiptsDb.js
+++ b/rest/src/plugins/receipts/ReceiptsDb.js
@@ -19,7 +19,7 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const { convertToLong, buildOffsetCondition, uniqueLongList } = require('../../db/dbUtils');
+const { convertToLong, buildOffsetCondition } = require('../../db/dbUtils');
 const catapult = require('catapult-sdk');
 
 const { convert, uint64 } = catapult.utils;
@@ -116,7 +116,7 @@ class ReceiptsDb {
 	}
 
 	/**
-	 * It retrives and adds the blocks information to the statements' meta.
+	 * It retrieves and adds the blocks information to the statements' meta.
 	 *
 	 * The block information includes the its timestamp
 	 *
@@ -124,30 +124,7 @@ class ReceiptsDb {
 	 * @returns {Promise<{pagination, data}>} the page with the added block's meta to the items.
 	 */
 	async addBlockMeta(page) {
-		const blockHeights = uniqueLongList(
-			page.data.map(pageItem => pageItem.statement.height)
-		);
-		const blocks = await this.catapultDb.blocksAtHeights(blockHeights,
-			{ 'block.timestamp': 1, 'block.height': 1 });
-		const data = page.data.map(pageItem => {
-			const statementBlock = blocks.find(
-				blockInfo => blockInfo.block.height.equals(
-					pageItem.statement.height
-				)
-			);
-			if (!statementBlock) {
-				throw new Error(
-					`Cannot find block with height ${pageItem.statement.height.toString()}`
-				);
-			}
-			if (!statementBlock.block.timestamp) {
-				throw new Error(
-					`Cannot find timestamp in block with height ${pageItem.statement.height.toString()}`
-				);
-			}
-			// creates a copy of the page item with the added timestamp to the meta field.
-			return { meta: { ...pageItem.meta, timestamp: statementBlock.block.timestamp }, ...pageItem };
-		});
+		const data = await this.catapultDb.addBlockMetaToEntityList(page.data, ['timestamp'], item => item.statement.height);
 		return { data, pagination: page.pagination };
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/symbol/catapult-rest/issues/637. 

It adds blocks' timestamp and feeMultiplier to the transactions endpoints (search, multiple, and single results by id/hash). It also adds timestamp and feeMultiplier to inner transactions meta (unsure if this is ok or not).

![image](https://user-images.githubusercontent.com/5390558/131708916-ed70d3a5-1a82-4bbe-98ee-88dd3df6906a.png)

 
![image](https://user-images.githubusercontent.com/5390558/131708876-6e9b6a4a-fa5c-4304-85d4-6c35a0cb09e9.png)
