### PR TITLE
fix: docker image base migrated to ubuntu v20.04 and zeromq version upgraded to v5.2.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,23 @@
-FROM node:12.18.1-alpine
-RUN apk add --update\
- python \
- python3 \
- build-base \
- zeromq-dev \
- && rm -rf /var/cache/apk/*
+FROM ubuntu:20.04
+
+ENV NODE_VERSION=12.18.1
+ENV NVM_DIR=/root/.nvm
+
+RUN mkdir -p ${NVM_DIR}
+RUN apt-get update && apt-get install -y curl
+
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
+RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
+RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
+RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
+ENV PATH="${NVM_DIR}/versions/node/v${NODE_VERSION}/bin/:${PATH}"
+RUN node --version
+RUN npm --version
+
+RUN npm install -g yarn
+
 WORKDIR /app
 COPY . /app/catapult-rest
 RUN cd catapult-rest \
- && ./yarn_setup.sh
-RUN cd catapult-rest/rest
+    && ./yarn_setup.sh
 WORKDIR /app/catapult-rest/rest

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,5 @@ RUN npm install -g yarn
 
 WORKDIR /app
 COPY . /app/catapult-rest
-RUN cd catapult-rest \
-    && ./yarn_setup.sh
+RUN cd catapult-rest && ./yarn_setup.sh
 WORKDIR /app/catapult-rest/rest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 
 ENV NODE_VERSION=12.18.1
-ENV NVM_DIR=/root/.nvm
+ENV NVM_DIR=/usr/local/.nvm
 
 RUN mkdir -p ${NVM_DIR}
 RUN apt-get update && apt-get install -y curl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,11 @@
 FROM ubuntu:20.04
 
-ENV NODE_VERSION=12.18.1
-ENV NVM_DIR=/usr/local/.nvm
-
-RUN mkdir -p ${NVM_DIR}
-RUN apt-get update && apt-get install -y curl
-
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
-RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
-RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
-RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
-ENV PATH="${NVM_DIR}/versions/node/v${NODE_VERSION}/bin/:${PATH}"
-RUN node --version
-RUN npm --version
-
-RUN npm install -g yarn
+RUN apt-get update && apt-get install -y curl \
+    && curl -fsSL https://deb.nodesource.com/setup_12.x | bash - \
+    && apt-get install -y nodejs \
+    && node --version \
+    && npm --version \
+    && npm install -g yarn
 
 WORKDIR /app
 COPY . /app/catapult-rest

--- a/rest/package.json
+++ b/rest/package.json
@@ -15,7 +15,7 @@
     "lint:fix": "eslint src test --fix",
     "lint:jenkins": "eslint -o tests.catapult.lint.xml -f junit src test || exit 0",
     "bootstrap-clean": "symbol-bootstrap clean",
-    "bootstrap-start": "symbol-bootstrap start -a light -c bootstrap-preset.yml --healthCheck --noPassword",
+    "bootstrap-start": "symbol-bootstrap start -a light -c bootstrap-preset-local.yml --healthCheck --noPassword",
     "bootstrap-start-testnet": "symbol-bootstrap start -p testnet -a dual -c bootstrap-preset-testnet.yml --healthCheck --noPassword",
     "bootstrap-start-mainnet": "symbol-bootstrap start -p testnet -a dual -c bootstrap-preset-mainnet.yml --healthCheck --noPassword",
     "bootstrap-start-detached": "symbol-bootstrap start -a light -c bootstrap-preset.yml --detached --healthCheck --noPassword",
@@ -57,6 +57,6 @@
     "sshpk": "1.16.1",
     "winston": "^3.2.1",
     "ws": "^7.1.0",
-    "zeromq": "^5.1.0"
+    "zeromq": "^5.2.8"
   }
 }

--- a/rest/yarn.lock
+++ b/rest/yarn.lock
@@ -7232,7 +7232,7 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zeromq@^5.1.0:
+zeromq@^5.2.8:
   version "5.2.8"
   resolved "https://registry.yarnpkg.com/zeromq/-/zeromq-5.2.8.tgz#94b0b85e4152e98b8bb163f1db4a34280d44d9d0"
   integrity sha512-bXzsk7KOmgLSv1tC0Ms1VXBy90+Rz27ZYf27cLuldRYbpqYpuWJfxxHFhO710t22zgWBnmdUP0m3SKFpLI0u5g==


### PR DESCRIPTION
fixes #657 

* in order to use the same base image(_ubuntu:20.04_) across all images(to save disk space), had to write a custom docker file since [the official docker node releases](https://hub.docker.com/_/node) are depending on the debian instead of ubuntu(_which is also based on debian_ but the docker images are unrelated thus no reuse).
    * https://github.com/nodejs/docker-node/tree/dc340d0bf2119dee534106ef012e85861cda8b84#image-variants
    * https://github.com/tianon/docker-brew-ubuntu-core/blob/49f002ba206e2cea2024aaa9f6f4ee4e9fb5c084/focal/Dockerfile
* kept the same node version in the previous docker file(node v12.18.1)
* tested locally ✓ 
     * run a local bootstrap(w/ testnet preset and local rest image), connected local wallet to the local node(screencast 👇 )
     https://www.loom.com/share/a69ee04c31b849d8bf922c96e775afdf
     * run a script using SDK block listener, result 👇 
     
![image](https://user-images.githubusercontent.com/6256269/132853593-43cd603c-9001-4439-848f-03e364f008f5.png)


