### PR TITLE
release 2.3.7 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [v2.3.7] - 31-Oct-2021
+
+### Added
+
+- Native HTTPS support by providing SSL certificates.
+- `timestamp` in recipients payload.
+- `timestamp` and `feeMultipler`in transactions payloads.
+
+### Fixed
+
+- Removed babel from local `catapult-sdk` module.
+- Docker image migrated to ubuntu v20.04.
+
 ## [v2.3.6] - 24-May-2021
 
 ### Added


### PR DESCRIPTION
For the next bootstrap release. 
Note that it doesn't include anything related to address format change (we have disabled that), We would add back that in version 2.4.0 (breaking change)