### PR TITLE
fix: removed private network type support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [v2.3.8] - 1-Nov-2021
+
+### Added
+
+- Removed private network type support.
+- Renamed network names to from `public` to `mainnet` and from `publicTest` to `testnet`.
+
 ## [v2.3.7] - 31-Oct-2021
 
 ### Added

--- a/catapult-sdk/src/model/networkInfo.js
+++ b/catapult-sdk/src/model/networkInfo.js
@@ -39,20 +39,12 @@ const networks = (() => {
 	/**
 	 * Information about well known catapult networks.
 	 * @typedef {object} WellKnownNetworks
-	 * @property {NetworkInfo} mijin Mijin network information.
-	 * @property {NetworkInfo} mijinTest Mijin test network information.
-	 * @property {NetworkInfo} public Public network information.
-	 * @property {NetworkInfo} publicTest Public test network information.
-	 * @property {NetworkInfo} private Private network information.
-	 * @property {NetworkInfo} private Private test network information.
+	 * @property {NetworkInfo} mainnet Public network information.
+	 * @property {NetworkInfo} testnet Public test network information.
 	 */
 	return {
-		mijin: createNetworkInfo(0x60),
-		mijinTest: createNetworkInfo(0x90),
-		public: createNetworkInfo(0x68),
-		publicTest: createNetworkInfo(0x98),
-		private: createNetworkInfo(0x78),
-		privateTest: createNetworkInfo(0xa8)
+		mainnet: createNetworkInfo(0x68),
+		testnet: createNetworkInfo(0x98)
 	};
 })();
 

--- a/catapult-sdk/test/model/address_spec.js
+++ b/catapult-sdk/test/model/address_spec.js
@@ -25,8 +25,8 @@ const test = require('../testUtils');
 const { expect } = require('chai');
 
 const Address_Decoded_Size = 24;
-const Network_Mijin_Identifier = 0x60;
-const Network_Public_Test_Identifier = 0x98;
+const Network_Mainnet_Identifier = 0x68;
+const Network_Testnet_Identifier = 0x98;
 
 describe('address', () => {
 	describe('stringToAddress', () => {
@@ -95,14 +95,14 @@ describe('address', () => {
 	describe('publicKeyToAddress', () => {
 		it('can create address from public key for well known network', () => {
 			// Arrange:
-			const expectedHex = '6023BB7C3C089D996585466380EDBDC19D49591848B37277';
+			const expectedHex = '6823BB7C3C089D996585466380EDBDC19D4959184893E38C';
 			const publicKey = convert.hexToUint8('3485D98EFD7EB07ADAFCFD1A157D89DE2796A95E780813C0258AF3F5F84ED8CB');
 
 			// Act:
-			const decoded = address.publicKeyToAddress(publicKey, Network_Mijin_Identifier);
+			const decoded = address.publicKeyToAddress(publicKey, Network_Mainnet_Identifier);
 
 			// Assert:
-			expect(decoded[0]).to.equal(Network_Mijin_Identifier);
+			expect(decoded[0]).to.equal(Network_Mainnet_Identifier);
 			expect(address.isValidAddress(decoded)).to.equal(true);
 			expect(convert.uint8ToHex(decoded)).to.equal(expectedHex);
 		});
@@ -113,10 +113,10 @@ describe('address', () => {
 			const publicKey = convert.hexToUint8('3485D98EFD7EB07ADAFCFD1A157D89DE2796A95E780813C0258AF3F5F84ED8CB');
 
 			// Act:
-			const decoded = address.publicKeyToAddress(publicKey, Network_Public_Test_Identifier);
+			const decoded = address.publicKeyToAddress(publicKey, Network_Testnet_Identifier);
 
 			// Assert:
-			expect(decoded[0]).to.equal(Network_Public_Test_Identifier);
+			expect(decoded[0]).to.equal(Network_Testnet_Identifier);
 			expect(address.isValidAddress(decoded)).to.equal(true);
 			expect(convert.uint8ToHex(decoded)).to.equal(expectedHex);
 		});
@@ -126,8 +126,8 @@ describe('address', () => {
 			const publicKey = convert.hexToUint8('3485D98EFD7EB07ADAFCFD1A157D89DE2796A95E780813C0258AF3F5F84ED8CB');
 
 			// Act:
-			const decoded1 = address.publicKeyToAddress(publicKey, Network_Mijin_Identifier);
-			const decoded2 = address.publicKeyToAddress(publicKey, Network_Mijin_Identifier);
+			const decoded1 = address.publicKeyToAddress(publicKey, Network_Mainnet_Identifier);
+			const decoded2 = address.publicKeyToAddress(publicKey, Network_Mainnet_Identifier);
 
 			// Assert:
 			expect(address.isValidAddress(decoded1)).to.equal(true);
@@ -140,8 +140,8 @@ describe('address', () => {
 			const publicKey2 = test.random.publicKey();
 
 			// Act:
-			const decoded1 = address.publicKeyToAddress(publicKey1, Network_Mijin_Identifier);
-			const decoded2 = address.publicKeyToAddress(publicKey2, Network_Mijin_Identifier);
+			const decoded1 = address.publicKeyToAddress(publicKey1, Network_Mainnet_Identifier);
+			const decoded2 = address.publicKeyToAddress(publicKey2, Network_Mainnet_Identifier);
 
 			// Assert:
 			expect(address.isValidAddress(decoded1)).to.equal(true);
@@ -154,8 +154,8 @@ describe('address', () => {
 			const publicKey = test.random.publicKey();
 
 			// Act:
-			const decoded1 = address.publicKeyToAddress(publicKey, Network_Mijin_Identifier);
-			const decoded2 = address.publicKeyToAddress(publicKey, Network_Public_Test_Identifier);
+			const decoded1 = address.publicKeyToAddress(publicKey, Network_Mainnet_Identifier);
+			const decoded2 = address.publicKeyToAddress(publicKey, Network_Testnet_Identifier);
 
 			// Assert:
 			expect(address.isValidAddress(decoded1)).to.equal(true);

--- a/catapult-sdk/test/model/networkInfo_spec.js
+++ b/catapult-sdk/test/model/networkInfo_spec.js
@@ -30,43 +30,19 @@ describe('network info', () => {
 
 			// Assert:
 			expect(knownNetworks).to.deep.equal([
-				'mijin',
-				'mijinTest',
-				'public',
-				'publicTest',
-				'private',
-				'privateTest'
+				'mainnet',
+				'testnet'
 			]);
 		});
 
-		it('defines mijin network', () => {
+		it('defines the mainnet network', () => {
 			// Assert:
-			expect(networkInfo.networks.mijin).to.deep.equal({ id: 0x60, bytePrefix: '60', charPrefix: 'M' });
+			expect(networkInfo.networks.mainnet).to.deep.equal({ id: 0x68, bytePrefix: '68', charPrefix: 'N' });
 		});
 
-		it('defines mijin test network', () => {
+		it('defines the testnet network', () => {
 			// Assert:
-			expect(networkInfo.networks.mijinTest).to.deep.equal({ id: 0x90, bytePrefix: '90', charPrefix: 'S' });
-		});
-
-		it('defines public network', () => {
-			// Assert:
-			expect(networkInfo.networks.public).to.deep.equal({ id: 0x68, bytePrefix: '68', charPrefix: 'N' });
-		});
-
-		it('defines public test network', () => {
-			// Assert:
-			expect(networkInfo.networks.publicTest).to.deep.equal({ id: 0x98, bytePrefix: '98', charPrefix: 'T' });
-		});
-
-		it('defines private network', () => {
-			// Assert:
-			expect(networkInfo.networks.private).to.deep.equal({ id: 0x78, bytePrefix: '78', charPrefix: 'P' });
-		});
-
-		it('defines private test test network', () => {
-			// Assert:
-			expect(networkInfo.networks.privateTest).to.deep.equal({ id: 0xa8, bytePrefix: 'A8', charPrefix: 'V' });
+			expect(networkInfo.networks.testnet).to.deep.equal({ id: 0x98, bytePrefix: '98', charPrefix: 'T' });
 		});
 	});
 

--- a/rest/resources/rest.json
+++ b/rest/resources/rest.json
@@ -1,7 +1,7 @@
 {
   "network": {
-    "name": "mijinTest",
-    "description": "catapult development network"
+    "name": "testnet",
+    "description": "catapult public test network"
   },
 
   "port": 3000,

--- a/rest/test/db/CatapultDb_spec.js
+++ b/rest/test/db/CatapultDb_spec.js
@@ -31,7 +31,7 @@ const sinon = require('sinon');
 const { address, EntityType } = catapult.model;
 
 const { Long, Binary } = MongoDb;
-const Mijin_Test_Network = testDbOptions.networkId;
+const Testnet_Network = testDbOptions.networkId;
 const Default_Height = 34567;
 
 const DefaultPagingOptions = {
@@ -63,11 +63,11 @@ describe('catapult db', () => {
 		return dbObject;
 	};
 
-	const keyToAddress = key => Buffer.from(address.publicKeyToAddress(key, Mijin_Test_Network));
+	const keyToAddress = key => Buffer.from(address.publicKeyToAddress(key, Testnet_Network));
 
 	const runDbTest = (dbEntities, issueDbCommand, assertDbCommandResult) => {
 		// Arrange:
-		const db = new CatapultDb(Object.assign({ networkId: Mijin_Test_Network }, DefaultPagingOptions));
+		const db = new CatapultDb(Object.assign({ networkId: Testnet_Network }, DefaultPagingOptions));
 
 		// Act + Assert:
 		return db.connect(testDbOptions.url, 'test', testDbOptions.connectionPoolSize)
@@ -121,7 +121,7 @@ describe('catapult db', () => {
 
 		it('can close unconnected db', () => {
 			// Arrange:
-			const db = new CatapultDb({ networkId: Mijin_Test_Network });
+			const db = new CatapultDb({ networkId: Testnet_Network });
 
 			// Act + Assert: no exception
 			expect(() => db.close()).to.not.throw();
@@ -396,7 +396,7 @@ describe('catapult db', () => {
 		});
 	});
 	const runBlockAtHeightDbTest = (dbEntities, issueDbCommand, assertDbCommandResult) => {
-		const db = new CatapultDb(Object.assign({ networkId: Mijin_Test_Network }, DefaultPagingOptions));
+		const db = new CatapultDb(Object.assign({ networkId: Testnet_Network }, DefaultPagingOptions));
 		return db.connect(testDbOptions.url, 'test', testDbOptions.connectionPoolSize)
 			.then(() => test.db.populateDatabase(db, dbEntities))
 			.then(() => issueDbCommand(db))
@@ -756,7 +756,7 @@ describe('catapult db', () => {
 	describe('transaction by id', () => {
 		const runTransactionsDbTest = (dbEntities, issueDbCommand, assertDbCommandResult) => {
 			// Arrange:
-			const db = new CatapultDb(Object.assign({ networkId: Mijin_Test_Network }, DefaultPagingOptions));
+			const db = new CatapultDb(Object.assign({ networkId: Testnet_Network }, DefaultPagingOptions));
 
 			// Act + Assert:
 			return db.connect(testDbOptions.url, 'test', testDbOptions.connectionPoolSize)
@@ -919,7 +919,7 @@ describe('catapult db', () => {
 				it(group, () => {
 					// Arrange:
 					const transactionsByIdsImplStub = sinon.stub(CatapultDb.prototype, 'transactionsByIdsImpl').returns('');
-					const db = new CatapultDb(Object.assign({ networkId: Mijin_Test_Network }, DefaultPagingOptions));
+					const db = new CatapultDb(Object.assign({ networkId: Testnet_Network }, DefaultPagingOptions));
 
 					// Act
 					db[dbCall](group, [param]);
@@ -2413,7 +2413,7 @@ describe('catapult db', () => {
 
 		const runAccountByIdsDbTest = (dbEntities, issueDbCommand, assertDbCommandResult) => {
 			// Arrange:
-			const db = new CatapultDb(Object.assign({ networkId: Mijin_Test_Network }, DefaultPagingOptions));
+			const db = new CatapultDb(Object.assign({ networkId: Testnet_Network }, DefaultPagingOptions));
 
 			// Act + Assert:
 			return db.connect(testDbOptions.url, 'test', testDbOptions.connectionPoolSize)

--- a/rest/test/db/utils/testDbOptions.js
+++ b/rest/test/db/utils/testDbOptions.js
@@ -28,6 +28,6 @@ module.exports = {
 		const mongoHost = args.mongoHost || '127.0.0.1';
 		return `mongodb://${mongoHost}:27017/`;
 	})(),
-	networkId: catapult.model.networkInfo.networks.mijinTest.id,
+	networkId: catapult.model.networkInfo.networks.testnet.id,
 	connectionPoolSize: 5
 };

--- a/rest/test/plugins/restrictions/restrictions_spec.js
+++ b/rest/test/plugins/restrictions/restrictions_spec.js
@@ -36,7 +36,7 @@ describe('restrictions plugin', () => {
 			const server = test.setup.createCapturingMockServer('get', routes);
 
 			// Act:
-			restrictions.registerRoutes(server, {}, { network: { name: 'mijinTest' } });
+			restrictions.registerRoutes(server, {}, { network: { name: 'testnet' } });
 
 			// Assert:
 			test.assert.assertRoutes(routes, [

--- a/rest/test/plugins/routeSystem_spec.js
+++ b/rest/test/plugins/routeSystem_spec.js
@@ -24,7 +24,7 @@ const { test } = require('../routes/utils/routeTestUtils');
 const { expect } = require('chai');
 
 describe('route system', () => {
-	const servicesTemplate = { config: { websocket: {}, network: { name: 'publicTest' } }, connections: {} };
+	const servicesTemplate = { config: { websocket: {}, network: { name: 'testnet' } }, connections: {} };
 	const configureTrailingParameters = [{ put: () => {} }, {}, servicesTemplate];
 
 	it('cannot register unknown extension', () => {
@@ -158,7 +158,7 @@ describe('route system', () => {
 
 		it('extension filter accepts marker without topic param with allowOptionalAddress', () => {
 			// Arrange:
-			const services = { config: { websocket: { allowOptionalAddress: true }, network: { name: 'publicTest' } }, connections: {} };
+			const services = { config: { websocket: { allowOptionalAddress: true }, network: { name: 'testnet' } }, connections: {} };
 			const { messageChannelDescriptors } = routeSystem.configure(['aggregate'], { put: () => {} }, {}, services);
 			const { filter } = messageChannelDescriptors.partialAdded;
 

--- a/rest/test/routes/dbFacade_spec.js
+++ b/rest/test/routes/dbFacade_spec.js
@@ -27,7 +27,7 @@ const { expect } = require('chai');
 const { Binary } = require('mongodb');
 const sinon = require('sinon');
 
-const Mijin_Test_Network = testDbOptions.networkId;
+const Testnet_Network = testDbOptions.networkId;
 
 describe('db facade', () => {
 	describe('run height dependent operation', () => {
@@ -61,7 +61,7 @@ describe('db facade', () => {
 			// Act:
 			const hashes = [1, 2, 3, 4];
 			const transactionStates = [{ dbPostfix: 'Custom', friendlyName: 'custom' }];
-			const db = new CatapultDb({ networkId: Mijin_Test_Network });
+			const db = new CatapultDb({ networkId: Testnet_Network });
 			return dbFacade.transactionStatusesByHashes(db, hashes, transactionStates).then(result => {
 				expect(transactionsByHashesFailedStub.withArgs(hashes).callCount).to.equal(1);
 				expect(transactionsByHashesStub.withArgs('confirmed', hashes).callCount).to.equal(1);

--- a/rest/test/routes/networkRoutes_spec.js
+++ b/rest/test/routes/networkRoutes_spec.js
@@ -69,7 +69,7 @@ describe('network routes', () => {
 			it('can retrieve network properties', () => {
 				const readFileStub = sinon.stub(fs, 'readFile').callsFake((path, data, callback) =>
 					callback(null, '[network]\n'
-						+ 'identifier = mijin-test\n'
+						+ 'identifier = testnet\n'
 						+ '[chain]\n'
 						+ 'enableVerifiableState = true\n'
 						+ '[plugin:catapult.plugins.aggregate]\n'
@@ -84,7 +84,7 @@ describe('network routes', () => {
 				return mockServer.callRoute(route).then(() => {
 					expect(mockServer.next.calledOnce).to.equal(true);
 					expect(mockServer.send.firstCall.args[0]).to.deep.equal({
-						network: { identifier: 'mijin-test' },
+						network: { identifier: 'testnet' },
 						chain: { enableVerifiableState: true },
 						plugins: { aggregate: { maxTransactionsPerAggregate: '1\'000' } }
 					});
@@ -95,7 +95,7 @@ describe('network routes', () => {
 			it('skips non-explicit properties', () => {
 				const readFileStub = sinon.stub(fs, 'readFile').callsFake((path, data, callback) =>
 					callback(null, '[network]\n'
-						+ 'identifier = mijin-test\n'
+						+ 'identifier = testnet\n'
 						+ '[chain]\n'
 						+ 'enableVerifiableState = true\n'
 						+ '[private]\n'
@@ -112,7 +112,7 @@ describe('network routes', () => {
 				return mockServer.callRoute(route).then(() => {
 					expect(mockServer.next.calledOnce).to.equal(true);
 					expect(mockServer.send.firstCall.args[0]).to.deep.equal({
-						network: { identifier: 'mijin-test' },
+						network: { identifier: 'testnet' },
 						chain: { enableVerifiableState: true },
 						plugins: { aggregate: { maxTransactionsPerAggregate: '1\'000' } }
 					});

--- a/spammer/src/index.js
+++ b/spammer/src/index.js
@@ -34,7 +34,7 @@ const modelCodec = catapult.plugins.catapultModelSystem.configure(['transfer', '
 const { uint64 } = catapult.utils;
 
 (() => {
-	const Mijin_Test_Network = catapult.model.networkInfo.networks.mijinTest.id;
+	const Testnet_Network = catapult.model.networkInfo.networks.testnet.id;
 	const options = spammerOptions.options();
 
 	const client = restify.createJsonClient({
@@ -70,7 +70,7 @@ const { uint64 } = catapult.utils;
 		for (let i = 0; i < options.predefinedRecipients; ++i) {
 			const keyPair = catapult.crypto.createKeyPairFromPrivateKeyString(curPrivateKey);
 			curPrivateKey = catapult.utils.convert.uint8ToHex(keyPair.publicKey);
-			recipients.push(address.publicKeyToAddress(keyPair.publicKey, Mijin_Test_Network));
+			recipients.push(address.publicKeyToAddress(keyPair.publicKey, Testnet_Network));
 		}
 
 		return () => recipients[random.uint32(options.predefinedRecipients - 1)];
@@ -80,7 +80,7 @@ const { uint64 } = catapult.utils;
 		const keySize = 32;
 		const privateKey = crypto.randomBytes(keySize);
 		const keyPair = catapult.crypto.createKeyPairFromPrivateKeyString(catapult.utils.convert.uint8ToHex(privateKey));
-		return address.publicKeyToAddress(keyPair.publicKey, Mijin_Test_Network);
+		return address.publicKeyToAddress(keyPair.publicKey, Testnet_Network);
 	};
 
 	const pickKeyPair = (privateKeys => {
@@ -93,7 +93,7 @@ const { uint64 } = catapult.utils;
 	const prepareTransferTransaction = txId => {
 		const keyPair = pickKeyPair();
 		const transfer = transactionFactory.createRandomTransfer(
-			{ signerPublicKey: keyPair.publicKey, networkId: Mijin_Test_Network, transferId: txId },
+			{ signerPublicKey: keyPair.publicKey, networkId: Testnet_Network, transferId: txId },
 			0 === options.predefinedRecipients ? randomRecipient : predefinedRecipient
 		);
 		transactionExtensions.sign(modelCodec, keyPair, transfer);
@@ -131,7 +131,7 @@ const { uint64 } = catapult.utils;
 
 	const createTransfer = (signerPublicKey, recipientAddress, transferId, amount) => {
 		const transfer = transactionFactory.createRandomTransfer(
-			{ signerPublicKey, networkId: Mijin_Test_Network, transferId },
+			{ signerPublicKey, networkId: Testnet_Network, transferId },
 			() => recipientAddress
 		);
 
@@ -145,7 +145,7 @@ const { uint64 } = catapult.utils;
 		const keyPairs = Array.from(Array(numProxies), randomKeyPair);
 		keyPairs.unshift(keyPairSender);
 
-		const addresses = keyPairs.map(keyPair => address.publicKeyToAddress(keyPair.publicKey, Mijin_Test_Network));
+		const addresses = keyPairs.map(keyPair => address.publicKeyToAddress(keyPair.publicKey, Testnet_Network));
 		const transfers = [];
 
 		for (let i = 0; i < numProxies; ++i) {
@@ -165,7 +165,7 @@ const { uint64 } = catapult.utils;
 		));
 
 		const aggregate = transactionFactory.createAggregateTransaction(
-			{ signerPublicKey: keyPairSender.publicKey, networkId: Mijin_Test_Network },
+			{ signerPublicKey: keyPairSender.publicKey, networkId: Testnet_Network },
 			transfers
 		);
 

--- a/spammer/test/model/transactionFactory_spec.js
+++ b/spammer/test/model/transactionFactory_spec.js
@@ -31,7 +31,7 @@ const createKey = catapult.crypto.createKeyPairFromPrivateKeyString;
 
 describe('transaction factory', () => {
 	const Private_Key = '8D31B712AB28D49591EAF5066E9E967B44507FC19C3D54D742F7B3A255CFF4AB';
-	const Mijin_Test_Network = catapult.model.networkInfo.networks.mijinTest.id;
+	const Testnet_Network = catapult.model.networkInfo.networks.testnet.id;
 
 	const assertTransactionData = (transaction, keyPair, version, type) => {
 		const txDeadline = catapult.utils.uint64.compact(transaction.deadline);
@@ -52,7 +52,7 @@ describe('transaction factory', () => {
 
 			// Act:
 			const transaction = transactionFactory.createRandomTransfer(
-				{ signerPublicKey: keyPair.publicKey, networkId: Mijin_Test_Network, transferId: 0x1234 },
+				{ signerPublicKey: keyPair.publicKey, networkId: Testnet_Network, transferId: 0x1234 },
 				() => recipientAddress
 			);
 


### PR DESCRIPTION
fix: renamed network types to `mainnet` and `testnet`.

Note, this is a configuration breaking change. Non bootstrap users would need to update the rest.json files