### PR TITLE
Feat: Add supply revocation transaction support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [v2.3.9] - 8-Nov-2021
+
+### Added
+
+- Added mosaic supply revocation transaction support.
+
 ## [v2.3.8] - 1-Nov-2021
 
 ### Added

--- a/catapult-sdk/src/model/EntityType.js
+++ b/catapult-sdk/src/model/EntityType.js
@@ -43,6 +43,9 @@ const EntityType = {
 	/** Mosaic supply change transaction. */
 	mosaicSupplyChange: 0x424D,
 
+	/** Mosaic supply revocation transaction. */
+	mosaicSupplyRevocation: 0x434d,
+
 	/** Modify multisig account transaction. */
 	modifyMultisigAccount: 0x4155,
 

--- a/catapult-sdk/src/plugins/mosaic.js
+++ b/catapult-sdk/src/plugins/mosaic.js
@@ -22,7 +22,9 @@
 /** @module plugins/mosaic */
 const EntityType = require('../model/EntityType');
 const ModelType = require('../model/ModelType');
+const sizes = require('../modelBinary/sizes');
 
+const constants = { sizes };
 /**
  * Creates a mosaic plugin.
  * @type {module:plugins/CatapultPlugin}
@@ -41,6 +43,12 @@ const mosaicPlugin = {
 			mosaicId: ModelType.uint64HexIdentifier,
 			delta: ModelType.uint64,
 			action: ModelType.uint8
+		});
+
+		builder.addTransactionSupport(EntityType.mosaicSupplyRevocation, {
+			sourceAddress: ModelType.encodedAddress,
+			mosaicId: ModelType.uint64HexIdentifier,
+			amount: ModelType.uint64
 		});
 
 		builder.addSchema('mosaicDescriptor', {
@@ -95,6 +103,22 @@ const mosaicPlugin = {
 				serializer.writeUint64(transaction.mosaicId);
 				serializer.writeUint64(transaction.delta);
 				serializer.writeUint8(transaction.action);
+			}
+		});
+
+		codecBuilder.addTransactionSupport(EntityType.mosaicSupplyRevocation, {
+			deserialize: parser => {
+				const transaction = {};
+				transaction.sourceAddress = parser.buffer(constants.sizes.addressDecoded);
+				transaction.mosaicId = parser.uint64();
+				transaction.amount = parser.uint64();
+				return transaction;
+			},
+
+			serialize: (transaction, serializer) => {
+				serializer.writeBuffer(transaction.sourceAddress);
+				serializer.writeUint64(transaction.mosaicId);
+				serializer.writeUint64(transaction.amount);
 			}
 		});
 	}

--- a/catapult-sdk/test/model/EntityType_spec.js
+++ b/catapult-sdk/test/model/EntityType_spec.js
@@ -32,6 +32,7 @@ describe('entity type enumeration', () => {
 			aliasMosaic: 0x434E,
 			mosaicDefinition: 0x414D,
 			mosaicSupplyChange: 0x424D,
+			mosaicSupplyRevocation: 0x434d,
 			modifyMultisigAccount: 0x4155,
 			aggregateComplete: 0x4141,
 			aggregateBonded: 0x4241,

--- a/catapult-sdk/test/plugins/mosaic_spec.js
+++ b/catapult-sdk/test/plugins/mosaic_spec.js
@@ -28,7 +28,8 @@ const { expect } = require('chai');
 const constants = {
 	sizes: {
 		mosaicDefinition: 22,
-		mosaicSupplyChange: 17
+		mosaicSupplyChange: 17,
+		mosaicSupplyRevocation: 40
 	}
 };
 
@@ -44,10 +45,11 @@ describe('mosaic plugin', () => {
 			const modelSchema = builder.build();
 
 			// Assert:
-			expect(Object.keys(modelSchema).length).to.equal(numDefaultKeys + 4);
+			expect(Object.keys(modelSchema).length).to.equal(numDefaultKeys + 5);
 			expect(modelSchema).to.contain.all.keys(
 				'mosaicDefinition',
 				'mosaicSupplyChange',
+				'mosaicSupplyRevocation',
 				'mosaicDescriptor',
 				'mosaicDescriptor.mosaic'
 			);
@@ -89,10 +91,11 @@ describe('mosaic plugin', () => {
 			const codecs = getCodecs();
 
 			// Assert: codecs were registered
-			expect(Object.keys(codecs).length).to.equal(2);
+			expect(Object.keys(codecs).length).to.equal(3);
 			expect(codecs).to.contain.all.keys([
 				EntityType.mosaicDefinition.toString(),
-				EntityType.mosaicSupplyChange.toString()
+				EntityType.mosaicSupplyChange.toString(),
+				EntityType.mosaicSupplyRevocation.toString()
 			]);
 		});
 
@@ -136,6 +139,26 @@ describe('mosaic plugin', () => {
 			});
 
 			test.binary.test.addAll(getCodec(EntityType.mosaicSupplyChange), constants.sizes.mosaicSupplyChange, generateTransaction);
+		});
+
+		describe('supports mosaic supply revokation', () => {
+			const sourceAddressBuffer = test.random.bytes(test.constants.sizes.addressDecoded);
+			const generateTransaction = () => ({
+				buffer: Buffer.concat([
+					sourceAddressBuffer, // source address
+					Buffer.of(0xF2, 0x26, 0x6C, 0x06, 0x40, 0x83, 0xB2, 0x92), // mosaic id
+					Buffer.of(0xCA, 0xD0, 0x8E, 0x6E, 0xFF, 0x21, 0x2F, 0x49) // amount
+				]),
+
+				object: {
+					sourceAddress: sourceAddressBuffer,
+					mosaicId: [0x066C26F2, 0x92B28340],
+					amount: [0x6E8ED0CA, 0x492F21FF]
+				}
+			});
+
+			test.binary.test.addAll(getCodec(EntityType.mosaicSupplyRevocation),
+				constants.sizes.mosaicSupplyRevocation, generateTransaction);
 		});
 	});
 });

--- a/rest/package.json
+++ b/rest/package.json
@@ -46,7 +46,7 @@
     "nyc": "^14.1.1",
     "rimraf": "^2.6.3",
     "sinon": "^7.3.2",
-    "symbol-bootstrap": "^1.1.0-alpha-202110051739"
+    "symbol-bootstrap": "^1.1.0"
   },
   "dependencies": {
     "catapult-sdk": "link:../catapult-sdk",

--- a/rest/yarn.lock
+++ b/rest/yarn.lock
@@ -1467,6 +1467,13 @@ cross-env@^5.2.0:
   dependencies:
     cross-spawn "^6.0.5"
 
+cross-fetch@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.4.tgz#9723f3a3a247bf8b89039f3a380a9244e8fa2f39"
+  integrity sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==
+  dependencies:
+    node-fetch "2.6.1"
+
 cross-spawn@^4:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
@@ -2665,12 +2672,7 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-github-from-package@0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
-  integrity sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=
-
-glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@~5.1.0:
+glob-parent@^5.0.0, glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -4472,6 +4474,11 @@ node-fetch-npm@^2.0.2:
     encoding "^0.1.11"
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
+
+node-fetch@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-fetch@^2.6.0:
   version "2.6.5"
@@ -6555,16 +6562,17 @@ supports-hyperlinks@^2.1.0:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
 
-symbol-bootstrap@^1.1.0-alpha-202110051739:
-  version "1.1.0-alpha-202110051739"
-  resolved "https://registry.yarnpkg.com/symbol-bootstrap/-/symbol-bootstrap-1.1.0-alpha-202110051739.tgz#f4bde604286c1b63fd59dae74e2f935f4239d618"
-  integrity sha512-+lvlQM2IDg76HuviUgcOhwtGN8SbO70w2ccmiVOkbsOBPaDir0AUGsqaRctnZU/eZNcszJymHdKHBX9W2KrObQ==
+symbol-bootstrap@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/symbol-bootstrap/-/symbol-bootstrap-1.1.0.tgz#4136fe704fdfe38dc77d33efa6d8d4b7d424e0ad"
+  integrity sha512-av4Znw8TqMjMeS3hEtTDw9pS6v/Hl4aJsWWOw/z9QEBlmL1PLAQh6LuS3M43jJWI8FaKJnUzvaJm5Y/TwQduYQ==
   dependencies:
     "@oclif/command" "^1.7.0"
     "@oclif/config" "^1.16.0"
     "@oclif/plugin-autocomplete" "^0.3.0"
     "@oclif/plugin-help" "^3.1.0"
     archiver "^5.2.0"
+    cross-fetch "^3.1.4"
     figlet "^1.2.4"
     handlebars "^4.7.7"
     inquirer "^7.3.3"
@@ -6577,6 +6585,7 @@ symbol-bootstrap@^1.1.0-alpha-202110051739:
     semver "^7.3.5"
     shx "^0.3.2"
     symbol-sdk "^1.0.1"
+    symbol-statistics-service-typescript-fetch-client "^1.1.1-SNAPSHOT.202110302303"
     tslib "^1.13.0"
     utf8 "^2.1.2"
     winston "^3.3.3"
@@ -6611,6 +6620,11 @@ symbol-sdk@^1.0.1:
     tweetnacl "^1.0.3"
     utf8 "^2.1.2"
     ws "^7.3.1"
+
+symbol-statistics-service-typescript-fetch-client@^1.1.1-SNAPSHOT.202110302303:
+  version "1.1.1-SNAPSHOT.202110302303"
+  resolved "https://registry.yarnpkg.com/symbol-statistics-service-typescript-fetch-client/-/symbol-statistics-service-typescript-fetch-client-1.1.1-SNAPSHOT.202110302303.tgz#586785ec277c16c4c5b27325b3865807d9395714"
+  integrity sha512-rFhjyOzkerFCk5S7enq6ugSf72Pa5ck3Cna6lXOBFFEiIKVkecQKm/anrcNFhs1ijhY53N6cJta/45mMJGXgiw==
 
 table@^5.2.3:
   version "5.4.6"


### PR DESCRIPTION
Current rest 2.3.8 doesn't support the new revoke transaction

- Ignores the new transactions fields 
- it fails to parse the new transaction payload when sending the transaction back to the web sockets

This PR fixes both related issues:

Rest payload: (Add to open api)
![image](https://user-images.githubusercontent.com/5390558/140773451-3f10779e-e5a3-4d79-92d9-fb14bd63c49d.png)

Listener payload

```
{
  "transaction": {
    "signature": "6F2FE34C6F09E8C4FB98569831E46A274809CA2D18405E811A0480EEC424C8034D51B65C692CA36BC0533733E4C7B83076B9F9B2FE439314B74E4AD78B36100F",
    "signerPublicKey": "5AB0BC217283542BF3BC45570FCC5C7232825B8DDDFBFF1F9CA06747BB939F92",
    "version": 1,
    "network": 152,
    "type": 17229,
    "maxFee": "2000000",
    "deadline": "62962930644",
    "sourceAddress": "986E584F3CE223A494D3444BDCA4A425AECED2B1C3318DF1",
    "mosaicId": "6CEE17786759C983",
    "amount": "1"
  },
  "meta": {
    "hash": "700E495D9E57B5701B3009BF02F522A9C1D7B15ECBBA65B3BD6F52A79EBBC7EB",
    "merkleComponentHash": "700E495D9E57B5701B3009BF02F522A9C1D7B15ECBBA65B3BD6F52A79EBBC7EB",
    "height": "212"
  }
}

```